### PR TITLE
Fix: Resolve SyntaxError and remove Babel Standalone

### DIFF
--- a/digital-record-label-agent-system-helper/index.html
+++ b/digital-record-label-agent-system-helper/index.html
@@ -63,14 +63,10 @@
   }
 }
 </script>
-<!-- Add Babel Standalone for client-side JSX/TSX transpilation -->
-<script src="https://unpkg.com/@babel/standalone@7.23.0/babel.min.js"></script>
 <link rel="stylesheet" href="/index.css">
 </head>
   <body class="bg-surface-dark font-sans">
     <div id="root"></div>
-    <!-- Script type changed to "text/babel" and data-presets added for Babel -->
-    <script type="text/babel" data-type="module" data-presets="env,react,typescript" src="/index.tsx"></script>
-  <script type="module" src="/index.tsx"></script>
-</body>
+    <script type="module" src="/index.tsx"></script>
+  </body>
 </html>


### PR DESCRIPTION
- I resolved an "Uncaught SyntaxError: Unexpected token ';'" by removing a redundant script tag in `index.html` that attempted to load `index.tsx` as a plain module.
- I removed the Babel Standalone library (`@babel/standalone`) from `index.html`.
- I updated the script tag for `index.tsx` to `type="module"`, relying on Vite's built-in capabilities for TypeScript/JSX transpilation.

This change ensures that the project uses Vite for development and builds as intended, addressing the warning about using the in-browser Babel transformer and preventing runtime errors due to misconfigured script loading.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed client-side Babel transpilation for JSX/TSX files; the application now loads scripts as native ES modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->